### PR TITLE
Fix: Add missing query parameters to transaction submission documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,21 +279,30 @@ Please note that the transaction details received belong to the quote from [step
 
 ### 4. Crypto Transaction
 
-The transaction details received in [step 3](#3-transaction-details) should now be used to construct the blockchain transaction. This process depends on the selected method.  
-Please make sure to use a transaction fee higher or equal to the minimum fee specified in the `minFee` field (gas price in WEI for EVM chains, sat/vB for Bitcoin) for the specific payment method (in JSON from [step 2](#2-payment-details)).  
+The transaction details received in [step 3](#3-transaction-details) should now be used to construct the blockchain transaction. This process depends on the selected method.
+Please make sure to use a transaction fee higher or equal to the minimum fee specified in the `minFee` field (gas price in WEI for EVM chains, sat/vB for Bitcoin) for the specific payment method (in JSON from [step 2](#2-payment-details)).
 The API URL to send the transaction prove back to the payment provider (see below) can be constructed by using the callback URL from [step 3](#3-transaction-details) and replacing `/cb` with `/tx`.
+
+**Important:** All transaction submission endpoints require the following query parameters:
+- `quote`: The quote ID from [step 2](#2-payment-details)
+- `method`: The blockchain/payment method name (must match exactly the method name from the `transferAmounts` array, e.g., "Ethereum", "BinanceSmartChain", "Polygon", etc.)
+- `hex`: The raw signed transaction in hexadecimal format
+- `tx`: (Only for Monero and certain other blockchains) The transaction ID after broadcasting
 
 #### EVM and Bitcoin
 
-Use the `uri` field from [step 3](#3-transaction-details) to construct and sign a valid transaction. Do not broadcast the transaction but send the raw signed transaction HEX to the payment provider with a GET HTTP request to the URL specified above. If the call returns a success HTTP code, the Open CryptoPay payment has been successfully completed.
+Use the `uri` field from [step 3](#3-transaction-details) to construct and sign a valid transaction. Do not broadcast the transaction but send the raw signed transaction HEX to the payment provider with a GET HTTP request to the URL specified above. You must include the `quote` ID from [step 2](#2-payment-details) and the `method` parameter (blockchain name) in the request. If the call returns a success HTTP code, the Open CryptoPay payment has been successfully completed.
 
-In our example the URL would be https://api.dfx.swiss/v1/lnurlp/tx/plp_f1ba466e2f1c0a4e?hex={raw-tx-hex}.
+In our example the URL would be https://api.dfx.swiss/v1/lnurlp/tx/plp_f1ba466e2f1c0a4e?quote={quote-id}&method={selected-method}&hex={raw-tx-hex}.
+
+For example, for an Ethereum payment: https://api.dfx.swiss/v1/lnurlp/tx/plp_f1ba466e2f1c0a4e?quote=plq_9af8927afe14f2d0&method=Ethereum&hex={raw-tx-hex}.
+For a BNB Smart Chain payment: https://api.dfx.swiss/v1/lnurlp/tx/plp_f1ba466e2f1c0a4e?quote=plq_9af8927afe14f2d0&method=BinanceSmartChain&hex={raw-tx-hex}.
 
 #### Monero
 
-Use the `uri` field from [step 3](#3-transaction-details) to construct a valid transaction. Broadcast this transaction to the network and send the resulting raw transaction HEX and the transaction ID to the payment provider with a GET HTTP request to the URL specified above. If the call returns a success HTTP code, the Open CryptoPay payment has been successfully completed.
+Use the `uri` field from [step 3](#3-transaction-details) to construct a valid transaction. Broadcast this transaction to the network and send the resulting raw transaction HEX and the transaction ID to the payment provider with a GET HTTP request to the URL specified above. You must include the `quote` ID from [step 2](#2-payment-details) and the `method` parameter in the request. If the call returns a success HTTP code, the Open CryptoPay payment has been successfully completed.
 
-In our example the URL would be https://api.dfx.swiss/v1/lnurlp/tx/plp_f1ba466e2f1c0a4e?hex={raw-tx-hex}&tx={tx-id}.
+In our example the URL would be https://api.dfx.swiss/v1/lnurlp/tx/plp_f1ba466e2f1c0a4e?quote={quote-id}&method=Monero&hex={raw-tx-hex}&tx={tx-id}.
 
 #### Lightning
 


### PR DESCRIPTION
## Summary
- Added missing 'quote' and 'method' parameters to the /tx endpoint documentation
- Clarified parameter requirements for EVM, Bitcoin, and Monero payment methods
- Added concrete examples showing correct parameter usage

## Problem
The current documentation was incomplete regarding required parameters when submitting signed transactions. This led to integration errors where wallets would receive "Invalid method Lightning for hex payment" errors when the method parameter was missing or incorrect.

## Solution
Updated the documentation to clearly specify:
- All required query parameters for transaction submission
- The exact format of the method parameter (must match the blockchain name from transferAmounts array)
- Specific examples for different blockchain types (Ethereum, BNB Smart Chain, Monero)

## Test plan
- [x] Documentation reviewed for accuracy
- [x] Examples tested against actual API behavior
- [x] Parameter requirements verified in source code