### PR TITLE
Fix urble link: urble.com → urble.io

### DIFF
--- a/ecosystem.html
+++ b/ecosystem.html
@@ -575,7 +575,7 @@
                 </div>
               </div>
             </a>
-            <a data-w-id="2784a533-0aff-7c45-973b-7713dfb7acf1" href="https://urble.com" target="_blank" class="card-ecosystem w-inline-block">
+            <a data-w-id="2784a533-0aff-7c45-973b-7713dfb7acf1" href="https://urble.io" target="_blank" class="card-ecosystem w-inline-block">
               <div class="header-2">
                 <div class="div-block-41"><img src="images/urble-logo.jpeg" loading="lazy" alt="urble" class="vectors-wrapper-23" style="width: 42px; height: 42px; border-radius: 8px;">
                   <div class="wallet-name">urble</div>
@@ -589,7 +589,7 @@
                   <div class="paragraph gray">urble is a mobile savings and payments app by Brick Towers, built on Bitcoin, Cardano, Ethereum and Midnight. It enables users to create personalized savings plans for themselves or loved ones, with contributions from friends and family. Through Open CryptoPay, urble users can also spend from their self-custodial wallet in everyday life, including at SPAR stores across Switzerland – connecting digital assets with real-world usage.</div>
                 </div>
                 <div data-w-id="f0c3cdce-2bbb-e4d3-f8e4-45cb9271048c" class="link-2">
-                  <div class="headline-15">urble.com</div><img src="images/arrow_outward-2.svg" loading="lazy" alt="" class="image-20">
+                  <div class="headline-15">urble.io</div><img src="images/arrow_outward-2.svg" loading="lazy" alt="" class="image-20">
                 </div>
               </div>
             </a>
@@ -1024,7 +1024,7 @@
                 </div>
               </div>
             </a>
-            <a data-w-id="2784a533-0aff-7c45-973b-7713dfb7acf1" href="https://urble.com" target="_blank" class="card-ecosystem w-inline-block">
+            <a data-w-id="2784a533-0aff-7c45-973b-7713dfb7acf1" href="https://urble.io" target="_blank" class="card-ecosystem w-inline-block">
               <div class="header-2">
                 <div class="div-block-41"><img src="images/urble-logo.jpeg" loading="lazy" alt="urble" class="vectors-wrapper-23" style="width: 42px; height: 42px; border-radius: 8px;">
                   <div class="wallet-name">urble</div>
@@ -1038,7 +1038,7 @@
                   <div class="paragraph gray">urble is a mobile savings and payments app by Brick Towers, built on Bitcoin, Cardano, Ethereum and Midnight. It enables users to create personalized savings plans for themselves or loved ones, with contributions from friends and family. Through Open CryptoPay, urble users can also spend from their self-custodial wallet in everyday life, including at SPAR stores across Switzerland – connecting digital assets with real-world usage.</div>
                 </div>
                 <div data-w-id="f0c3cdce-2bbb-e4d3-f8e4-45cb9271048c" class="link-2">
-                  <div class="headline-15">urble.com</div><img src="images/arrow_outward-2.svg" loading="lazy" alt="" class="image-20">
+                  <div class="headline-15">urble.io</div><img src="images/arrow_outward-2.svg" loading="lazy" alt="" class="image-20">
                 </div>
               </div>
             </a>


### PR DESCRIPTION
## Summary
- Fix urble wallet link on ecosystem page from urble.com to urble.io
- Updated both href and display text (2 occurrences each)